### PR TITLE
Remove CNAME entry

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-vtjeng.com


### PR DESCRIPTION
We are now serving our home page via Cloudflare pages.

This means that redirecting vtjeng.github.io -> vtjeng.com ends up leading to broken documentation for https://github.com/vtjeng/MIPVerify.jl (since vtjeng.com/MIPVerify.jl is empty), which is undesired. We might get around to using a custom site for that project, but for now the docs will have to live at vtjeng.github.io/MIPVerify.jl
