### PR TITLE
Pin the Prettier version used by CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,4 +24,7 @@ jobs:
       - name: "Verify that Prettier does not find any code style issues."
         uses: creyD/prettier_action@v4.3
         with:
+          # Without a pin, the action installs the latest Prettier, and new releases
+          # change formatting rules and break CI on unchanged files.
+          prettier_version: "3.9.5"
           prettier_options: . --check


### PR DESCRIPTION
The format check ran `creyD/prettier_action` without `prettier_version`, so every run installed whatever Prettier had most recently released. A release that changes formatting rules then fails the check on files nobody touched — the failure mode MIPVerify.jl's CI documents in its own pin.

Pins 3.9.5, matching MIPVerify.jl. Verified with `npx prettier@3.9.5 --check .`: all 17 tracked files pass, so this changes no formatting.

_AI collaboration: co-produced with Claude Code (Anthropic)._
