### PR TITLE
Let Renovate keep the Prettier pin current

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,5 +26,6 @@ jobs:
         with:
           # Without a pin, the action installs the latest Prettier, and new releases
           # change formatting rules and break CI on unchanged files.
+          # renovate: datasource=npm depName=prettier
           prettier_version: "3.9.5"
           prettier_options: . --check

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Prettier version pinned as an input to the format-check action, marked with a `# renovate:` comment naming its datasource.",
+      "managerFilePatterns": ["/^\\.github/workflows/CI\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+[^\\n]*?version=?:? ?\"(?<currentValue>\\d[^\"]+)\""
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #56, which pinned Prettier to 3.9.5. Nothing updates that pin automatically, so this adds a Renovate config that will open the bump PRs.

Adds `renovate.json` with one custom manager: a rule that reads the pin in `.github/workflows/CI.yml` through a `# renovate: datasource=npm depName=prettier` comment, which tells Renovate to check npm for new versions. Renovate then opens one PR per new Prettier release, and the format check in that PR runs against the new version.

Renovate's built-in `github-actions` manager also covers the `uses:` action pins. Here, `actions/checkout` is at v3 and the current release is v7.

### Verification

- `renovate-config-validator` passes.
- `renovate --platform=local --dry-run=extract` extracts `prettier @ 3.9.5`.
- The workflow still parses as YAML (checked with `yaml.safe_load`).

Renovate is now installed on this repository and has opened onboarding PR #58, which proposes a `renovate.json` containing only `extends: ["config:recommended"]`. This config includes that preset, so #58 can be closed rather than merged.

_AI collaboration: co-produced with Claude Code (Anthropic)._

