### PR TITLE
Declare least-privilege permissions for the format check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,11 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# The format check only reads files. With this block present, every scope not
+# listed is set to none, so the third-party action in this job cannot push.
+permissions:
+  contents: read
+
 jobs:
   format-check-prettier:
     name: "Check Formatting (Prettier)"


### PR DESCRIPTION
Companion to vtjeng/MIPVerify.jl#252. Reduces what CI can do if a third-party action turns out to be malicious; touches no action versions and no third-party code.

### Problem

This repository's default `GITHUB_TOKEN` permission is **write**. CI.yml declared no `permissions` block, so `format-check-prettier` ran with a write-scoped token — and that job's only step is `creyD/prettier_action`, a community action whose job is to read files and report formatting problems.

### Effective permissions after this change

| Workflow / job | Before | After |
| --- | --- | --- |
| CI.yml workflow default | repo default (write-all) | `contents: read` |
| CI.yml `format-check-prettier` | repo default (write-all) | `contents: read` (inherited) |
| codeql-analysis.yml `analyze` | `actions: read`, `contents: read`, `security-events: write` | unchanged |

Declaring the block sets every unlisted scope to none, so the job also loses write access to pull requests, checks, statuses, and the rest.

This PR's own CI exercises the change: `format-check-prettier` runs on pull requests, and a read-only token is all it has ever needed.

### Verification

Both workflow files parse as YAML, and the effective per-job permissions were enumerated from the parsed files to produce the table above.

### Next

Two follow-ups, both separate: replacing `creyD/prettier_action` with a plain `npx prettier --check` step, which removes the third-party dependency rather than constraining it; and bumping `github/codeql-action` off v1, which has been end-of-life for years, along with `actions/checkout@v2`.

_AI collaboration: co-produced with Claude Code (Anthropic)._
