### PR TITLE
Run Prettier directly instead of through creyD/prettier_action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 # The format check only reads files. With this block present, every scope not
-# listed is set to none, so the third-party action in this job cannot push.
+# listed is set to none.
 permissions:
   contents: read
 
@@ -27,10 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Verify that Prettier does not find any code style issues."
-        uses: creyD/prettier_action@v4.3
-        with:
-          # Without a pin, the action installs the latest Prettier, and new releases
-          # change formatting rules and break CI on unchanged files.
-          # renovate: datasource=npm depName=prettier
-          prettier_version: "3.9.6"
-          prettier_options: . --check
+        # Without a pin, npx resolves the latest Prettier, and new releases change
+        # formatting rules and break CI on unchanged files.
+        # renovate: datasource=npm depName=prettier
+        run: npx --yes prettier@3.9.6 . --check

--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Prettier version pinned as an input to the format-check action, marked with a `# renovate:` comment naming its datasource.",
+      "description": "Prettier version pinned at its call site in the format-check step, marked with a `# renovate:` comment naming its datasource.",
       "managerFilePatterns": ["/^\\.github/workflows/CI\\.yml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+[^\\n]*?version=?:? ?\"(?<currentValue>\\d[^\"]+)\""
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+[^\\n]*?@(?<currentValue>\\d[^\\s\"']+)"
       ]
     }
   ]


### PR DESCRIPTION
Follow-up to #61, and the reason #60 was closed rather than merged.

#61 constrained what `creyD/prettier_action` could do with its token. This removes the action instead, so nothing beyond `actions/checkout` runs third-party code in this workflow.

### What the action was doing

It wrapped `prettier <options>` and installed the version given as `prettier_version`. The replacement is that call, with the pin moved to the call site:

```yaml
# renovate: datasource=npm depName=prettier
run: npx --yes prettier@3.9.6 . --check
```

`prettier_options` was already `. --check`, so the arguments are unchanged. Prettier 3 reads `.gitignore` by default, so `_site`, `vendor`, and the Jekyll caches stay excluded without a `.prettierignore`.

`renovate.json`'s custom manager matched `version: "..."`, which no longer appears. It now matches the `@version` form, reusing the pattern already written for `vtjeng/MIPVerify.jl#250` — that repo pins Prettier the same way in `scripts/format.sh`.

The comment above the `permissions:` block lost its reference to "the third-party action in this job", which is no longer accurate.

### Verification

- `npx --yes prettier@3.9.6 . --check` run against a clean checkout: "All matched files use Prettier code style!", and `--list-different` reports 0 files. So the new command agrees with the action's verdict on the current tree.
- `renovate-config-validator` passes on the new `renovate.json`.
- `renovate --platform=local --dry-run=extract` extracts `prettier @ 3.9.6` from `.github/workflows/CI.yml` through the custom manager, with `replaceString` covering `npx --yes prettier@3.9.6`. Without this change the manager would have silently stopped matching and the pin would have gone stale unnoticed.
- This PR's own `Check Formatting (Prettier)` run exercises the new step, and it is the required check on `master` — the migration is fully tested by CI, unlike the permissions work in MIPVerify.

### Note on npx and Node

The step uses the runner's preinstalled Node rather than pinning one with `actions/setup-node`. Prettier's output depends on the Prettier version, which is pinned; the Node version is not a formatting input. If that ever changes, adding `setup-node` is the fix.

### Still open in this repository

`actions/checkout@v2` in `codeql-analysis.yml` and `github/codeql-action@v1`, which has been end-of-life for years. Separate change; noted in #61 as well.

_AI collaboration: co-produced with Claude Code (Anthropic)._
