### PR TITLE
Drop MathJax

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The key differences are:
   - `head.html` is modified to allow for custom titles.
   - `footer.html` is modified to include only the social links, removing descriptions and contact
     details.
-  - `custom-head.html` adds a favicon and `MathJax` processing.
+  - `custom-head.html` adds a favicon, the Cairo webfont, and Font Awesome.
 
 > :pencil: Note that custom CSS is specified `assets/css/style.scss` (as referenced in the vendored
 > version of `_includes/head.html`), rather than in `assets/main.css`.

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -7,15 +7,6 @@
 <meta name="msapplication-TileColor" content="#b91d47" />
 <meta name="theme-color" content="#ffffff" />
 
-<!-- MathJax -->
-{% if page.MathJax %}
-<!-- Per http://www.iangoodfellow.com/blog/jekyll/markdown/tex/2016/11/07/latex-in-markdown.html -->
-<script
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-  type="text/javascript"
-></script>
-{% endif %}
-
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Cairo&display=swap" rel="stylesheet" />

--- a/index.md
+++ b/index.md
@@ -4,7 +4,6 @@ title-tag: "Vincent Tjeng"
 permalink: /
 # This description is what is used for SEO purposes.
 description: An overview of my current work, hobbies, and research.
-MathJax: True
 ---
 
 <p style="text-align: center">


### PR DESCRIPTION
Removes a dependency that did nothing and could not be updated.

`index.md` was the only page setting `MathJax: True`, and it has no math in it: no `$`, `$$`, `\(`, or `\[` anywhere in the file. The script loaded on every homepage view and rendered nothing.

The URL had rotted as well. `cdn.mathjax.org` was retired years ago. It still returns 200, which is why nothing flagged it, but the 1657 bytes it serves are a shim that rewrites the script tag to `cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js`. That is an extra round trip to be handed MathJax 2.7.1 from 2017, and Renovate cannot bump it because the version sits inside the shim rather than in our HTML. It was the only dependency in the repo that was both stale and invisible to the update tooling.

If math is needed again, add MathJax 3 or later directly rather than restoring this URL.

`README.md` described `custom-head.html` as doing MathJax processing, so it now says what the file actually does.

## Verification

Verified on the Cloudflare Pages preview rather than locally, since this machine has no `bundle` executable to build Jekyll. The served `/` contains 0 occurrences of `mathjax` and Chromium issues 0 requests to `cdn.mathjax.org`, with no console errors and no failed requests. The four Font Awesome footer icons still render, confirmed by computed style and screenshot.

`npx prettier@3.9.6 . --check` passes.

## Dropped from this PR

An earlier revision added a subresource integrity hash to the Font Awesome stylesheet. That is now out, and the `<link>` is byte-identical to `master`. Renovate bumps that URL but would not regenerate the hash, so its next bump would have passed CI and silently blanked every icon on the site, since a failed integrity check blocks the stylesheet without a visible error. That is the same rot-prone, tooling-invisible pin this PR exists to delete. The protection was also thin: it is CSS rather than JS, on a site with no login, no forms, and no PII.

_AI collaboration: co-produced with Claude Code (Anthropic)._
