### PR TITLE
Let releases settle for 14 days before Renovate proposes them

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "14 days",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Renovate currently proposes releases the moment they appear. In `MIPVerify.jl` that meant adopting JuliaFormatter 2.11.5 seven minutes after publication, during a run of six releases in five days where 2.11.5 existed to fix regressions introduced by 2.11.1.

`minimumReleaseAge` makes a release wait before Renovate will propose it. `internalChecksFilter` already defaults to `strict`, so no branch or PR is created until the window clears — there is no pending PR to look at.

Security updates are unaffected: the `vulnerabilityAlerts` defaults set `minimumReleaseAge` to `null`, so a CVE fix still opens immediately.

Applied to `MIPVerify.jl` in parallel with this.

_AI collaboration: co-produced with Claude Code (Anthropic)._